### PR TITLE
Refs #39 Update braintree api version

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -8,7 +8,7 @@ android {
 }
 
 dependencies {
-    compile 'com.braintreepayments.api:braintree:2.6.0'
+    compile 'com.braintreepayments.api:braintree:2.6.2'
     compile 'com.braintreepayments.api:drop-in:3.0.8'
     compile 'io.card:android-sdk:5.4.1'
 }


### PR DESCRIPTION
Fixes #39 

I think this throws on devices without wallet setup, I think the guys at braintree put a fix in here: https://github.com/braintree/braintree_android/commit/2c3d9ad9db68fa36e8290c979af6a809b451a865d

