### PR TITLE
Fix iOS error with hook script on cordova@7

### DIFF
--- a/scripts/add_embedded_ios_frameworks.js
+++ b/scripts/add_embedded_ios_frameworks.js
@@ -12,6 +12,8 @@ module.exports = function(context) {
         }
     }
 
+    if(parseInt(context.opts.cordova.version) >= 7) return; // cordova@7 embeds the frameworks so this script is not required
+
     function fromDir(startPath,filter, rec, multiple){
         if (!fs.existsSync(startPath)){
             console.log("no dir ", startPath);

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 def getPackageName() {
-    def config = file("res/xml/config.xml").getText()
+    def config = file("src/main/res/xml/config.xml").getText()
     def xml = new XmlParser(false, false).parseText(config)
     return xml.attribute("id")
 }

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -14,7 +14,11 @@ dependencies {
 }
 
 def getPackageName() {
-    def config = file("src/main/res/xml/config.xml").getText()
+    def configFile = new File("src/main/res/xml/config.xml");
+    if(!configFile.exists()){
+        configFile = new File("res/xml/config.xml");
+    }
+    def config = file(configFile).getText()
     def xml = new XmlParser(false, false).parseText(config)
     return xml.attribute("id")
 }


### PR DESCRIPTION
This fixes a build issue on iOS when using `cordova@7` caused by the `add_embedded_ios_frameworks.js` hook script which adds the frameworks to the Xcode project.

The error occurs because `cordova@7` itself now adds the embed configuration to the Xcode project, so running the hook script causes an error.

Subsequently, Xcode will not open the project: `Project /projects/@scratch/cordova-plugin-braintree-test/platforms/ios/Braintree Test.xcodeproj cannot be opened because the project file cannot be parsed.`

I've added a line to the hook script to abort if the Cordova CLI version is >= 7.

This is a similar issue to [this one](https://github.com/Tealium/cordova-plugin/issues/26) encountered with the Tealium plugin, and is possibly the cause of #34.

See below the console output using your current version of the plugin (which results in the error) vs the console output using my modified version:

<details>
<summary>console output for taracque/cordova-plugin-braintree</summary>

```

$ cordova -v
7.1.0

$ cordova plugin add https://github.com/taracque/cordova-plugin-braintree.git
Adding cordova-plugin-braintree to package.json
Saved plugin info for "cordova-plugin-braintree" to config.xml

$ cordova platform add ios
Using cordova-fetch for cordova-ios@^4.5.2
Adding ios project...
Creating Cordova project for the iOS platform:
    Path: platforms/ios
    Package: io.cordova.braintree.test
    Name: Braintree Test
iOS project created with cordova-ios@4.5.2
Installing "cordova-plugin-braintree" for ios
Embedded Frameworks in cordova-plugin-braintree
Added Arch stripping run script build phase
Installing "cordova-plugin-whitelist" for ios
--save flag or autosave detected
Saving ios@~4.5.2 into config.xml file ...
Embedded Frameworks in cordova-plugin-braintree
Added Arch stripping run script build phase

$ cordova prepare ios
Error: Expected "/* Begin ", "/* End ", "\"", or [A-Za-z0-9_.] but "/" found.
$

```

</details>


<details>
<summary>console output for dpa99c/cordova-plugin-braintree</summary>

```

$ cordova -v
7.1.0

$ cordova plugin add https://github.com/dpa99c/cordova-plugin-braintree.git
Adding cordova-plugin-braintree to package.json
Saved plugin info for "cordova-plugin-braintree" to config.xml

$ cordova platform add ios
Using cordova-fetch for cordova-ios@^4.5.2
Adding ios project...
Creating Cordova project for the iOS platform:
    Path: platforms/ios
    Package: io.cordova.braintree.test
    Name: Braintree Test
iOS project created with cordova-ios@4.5.2
Installing "cordova-plugin-braintree" for ios
Installing "cordova-plugin-whitelist" for ios
--save flag or autosave detected
Saving ios@~4.5.2 into config.xml file ...

$ cordova prepare ios
$ 

```

</details>
